### PR TITLE
fix: Update stylesheet registration and include all UI enhancements

### DIFF
--- a/DefaultManuscriptChildThemePlugin.php
+++ b/DefaultManuscriptChildThemePlugin.php
@@ -29,7 +29,7 @@ class DefaultManuscriptChildThemePlugin extends ThemePlugin {
 		$this->setParent('defaultthemeplugin');
 
 		// Add custom styles
-		$this->modifyStyle('stylesheet', array('addLess' => array('styles/index.less')));
+		$this->addStyle('defaultManuscriptChildStylesheet', 'styles/index.less', ['contexts' => 'frontend']);
 
 		// Remove the typography options of the parent theme.
 		$this->removeOption('typography');

--- a/styles/components.less
+++ b/styles/components.less
@@ -113,3 +113,56 @@
 	border-right: 1px solid @bg-border-color;
 	border-bottom: 1px solid @bg-border-color;
 }
+
+// Typographic Hierarchy
+//
+// Headings h1-h4 using @font-heading (Open Sans)
+// Classes .h1-.h4 are provided for semantic heading structure when a
+// different HTML tag is necessary.
+
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4 {
+	font-family: @font-heading;
+	font-weight: 700; // Bold
+	line-height: 1.2; // Standard for headings
+	margin-top: 1.5em;
+	margin-bottom: 0.75em;
+	color: @text-strong; // Assuming a dark color for headings, can be adjusted
+}
+
+h1, .h1 {
+	font-size: 2.5em;
+}
+
+h2, .h2 {
+	font-size: 2em;
+}
+
+h3, .h3 {
+	font-size: 1.75em;
+}
+
+h4, .h4 {
+	font-size: 1.5em;
+}
+
+// Accessibility: Visible Focus States
+// Ensure interactive elements have a clear visual indicator when they receive keyboard focus.
+// This provides a default style; specific components might need adjustments.
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus,
+[tabindex]:not([tabindex="-1"]):focus { // Include elements with tabindex
+	outline: 2px solid @primary-lift;
+	outline-offset: 1px;
+	// As an alternative or fallback if outlines are problematic on some elements:
+	// box-shadow: 0 0 0 2px @primary-lift;
+}
+
+// Remove default outline from elements that will receive custom focus styles elsewhere,
+// ONLY if a custom style is being applied. Otherwise, keep the outline.
+// Example: .custom-button-with-focus-style:focus { outline: none; /* custom style here */ }

--- a/styles/fonts.less
+++ b/styles/fonts.less
@@ -9,31 +9,7 @@
  *
  */
 @import "../../default/styles/fonts/notoSerif.less";
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Open+Sans:wght@400;700&display=swap');
 
-/* montserrat-regular - vietnamese_latin-ext_latin_cyrillic-ext_cyrillic */
-@font-face {
-  font-family: 'Montserrat';
-  font-style: normal;
-  font-weight: 400;
-  src: url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.eot'); /* IE9 Compat Modes */
-  src: local(''),
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.woff2') format('woff2'), /* Super Modern Browsers */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.woff') format('woff'), /* Modern Browsers */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.ttf') format('truetype'), /* Safari, Android, iOS */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-regular.svg#Montserrat') format('svg'); /* Legacy iOS */
-}
-
-/* montserrat-700 - vietnamese_latin-ext_latin_cyrillic-ext_cyrillic */
-@font-face {
-  font-family: 'Montserrat';
-  font-style: normal;
-  font-weight: 700;
-  src: url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.eot'); /* IE9 Compat Modes */
-  src: local(''),
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.woff2') format('woff2'), /* Super Modern Browsers */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.woff') format('woff'), /* Modern Browsers */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.ttf') format('truetype'), /* Safari, Android, iOS */
-       url('@{baseUrl}/plugins/themes/defaultManuscript/fonts/montserrat-v15-vietnamese_latin-ext_latin_cyrillic-ext_cyrillic-700.svg#Montserrat') format('svg'); /* Legacy iOS */
-}
+// Montserrat font-face declarations removed as per new typography guidelines.
+// Lato and Open Sans are now imported from Google Fonts.

--- a/styles/head.less
+++ b/styles/head.less
@@ -16,11 +16,8 @@
 
 .pkp_site_name_wrapper {
 	background: @bg-base;
-}
-
-.pkp_site_name_wrapper {
-	padding-left: @triple;
-	padding-right: @triple;
+	padding-left: @double; // Reduced from @triple
+	padding-right: @double; // Reduced from @triple
 }
 
 .pkp_site_name {
@@ -33,8 +30,8 @@
 	@media(min-width: @screen-desktop) {
 		width: 75%;
 		margin-left: 0;
-		padding-top: @base + @half;
-		padding-bottom: @base + @half;
+		padding-top: @half; // Reduced from @base + @half
+		padding-bottom: @half; // Reduced from @base + @half
 
 		.is_text {
 			font-size: @font-lead;
@@ -42,12 +39,158 @@
 	}
 }
 
+// Styles for Mobile Navigation (using @screen-md-max as breakpoint)
+@media (max-width: @screen-md-max) {
+
+	.pkp_site_name_wrapper {
+		// Potentially reduce padding further on mobile if needed
+		// padding-left: @base;
+		// padding-right: @base;
+	}
+
+	.pkp_site_name {
+		text-align: center; // Center site name on mobile
+		width: auto; // Allow it to take available width
+		padding-top: @base;
+		padding-bottom: @base;
+
+		.is_text {
+			font-size: @font-large; // Adjust size for mobile header
+		}
+	}
+
+	// Hide desktop primary navigation row
+	.pkp_navigation_primary_row {
+		display: none;
+	}
+
+	// Reset fixed positioning for user navigation, make it flow
+	.pkp_navigation_user_wrapper {
+		position: static;
+		width: 100%;
+		background: transparent;
+		padding: @half @base; // Add some padding
+		text-align: center; // Center user links
+
+		a {
+			color: @text-strong; // Standard text color
+			padding: @half;
+		}
+		.pkp_navigation_user {
+			justify-content: center; // Center items if it's flex
+			display: block; // Stack items
+			> li {
+				margin-left: 0;
+				margin-bottom: @half;
+				display: inline-block; // Or block if they should take full width
+				margin-right: @half; // Spacing for inline-block items
+			}
+		}
+	}
+
+	// Style for the mobile navigation toggle button
+	.pkp_site_nav_toggle {
+		display: block;
+		position: absolute;
+		top: 0; // Align with top of pkp_head_wrapper or pkp_site_name_wrapper
+		right: @base;
+		font-size: 1.8em;
+		background: transparent;
+		border: none;
+		color: @text-bg-base; // Color for hamburger on header background
+		padding: @half @base; // Make it easier to tap
+		z-index: 1010; // Ensure it's on top
+
+		// Adjust top position to vertically center with site name if site name wrapper has padding
+		// Example: if pkp_site_name_wrapper has padding-top/bottom of @base (1em)
+		// and site name font is ~1.2em, total height ~3.4em. Toggle line-height ~1.8em.
+		// (3.4em - 1.8em) / 2 = 0.8em top padding for wrapper, or adjust toggle top.
+		// This needs specific values from final header height.
+		// For now, a simple top/right.
+	}
+
+	// Desktop #navigationPrimary list (if not used for mobile dropdown)
+	// This is often hidden if #mainNavigationDropdown provides the mobile menu content
+	#navigationPrimary {
+		// If #mainNavigationDropdown is used, hide this:
+		// display: none;
+		// If #navigationPrimary IS the dropdown, its > li are already display:block.
+		// For now, assume a separate #mainNavigationDropdown will be styled.
+	}
+
+	.pkp_navigation_search_wrapper {
+		// Decide how to handle search on mobile.
+		// Option 1: Hide it if it's in the mainNavigationDropdown.
+		// display: none;
+		// Option 2: Style it as an icon or small link in the header.
+		text-align: center;
+		padding-bottom: @base;
+		a {
+			padding: @half;
+		}
+	}
+
+	// Styles for the mobile navigation panel itself
+	// This panel is typically hidden by default and shown by JavaScript when the toggle is clicked.
+	#mainNavigationDropdown {
+		// Basic styling, assuming it's a block that appears below the header or overlays
+		background-color: @bg-shade; // Use a light shade for dropdown background
+		border-top: 1px solid @bg-border-color;
+		position: absolute; // Positioned relative to .pkp_head_wrapper or .pkp_site_name_wrapper
+		top: 100%; // Place it below the header (assuming header is not fixed height)
+		left: 0;
+		width: 100%;
+		z-index: 1005; // Below toggle (1010) but above other content
+		padding: 0; // Remove padding from container, apply to links
+		box-shadow: @shadow-sm;
+		// IMPORTANT: Actual display:none/block is usually handled by JS via inline style or class.
+		// CSS alone can't easily do toggle without :target hack or checkbox hack.
+		// We assume JS will make it visible. Styles here are for its appearance when visible.
+
+		ul {
+			list-style: none;
+			padding: 0;
+			margin: 0;
+
+			li {
+				display: block; // Stack items vertically
+				a {
+					display: block;
+					padding: @base;
+					text-decoration: none;
+					color: @text-strong; // Dark text on light background
+					border-bottom: 1px solid lighten(@bg-border-color, 5%);
+
+					&:hover, &:focus {
+						background-color: darken(@bg-shade, 3%); // Slightly darken on hover
+						color: @primary;
+					}
+				}
+				&:last-child a {
+					border-bottom: none;
+				}
+			}
+		}
+
+		// This rule ensures it's hidden on desktop, in case JS doesn't do it.
+		@media (min-width: @screen-md-min) { // md-min is desktop
+			display: none !important;
+		}
+	}
+}
+
 @media(min-width: @screen-desktop) {
 
+	// Approximate height of the fixed user navigation bar
+	@user-nav-height: 2.5em;
+
 	.pkp_navigation_primary_row {
-		background: @bg;
-		padding-left: @triple;
-		padding-right: @triple;
+		background: @light-slate-gray; // Changed from @bg to reduce flat white
+		padding-left: @double; // Reduced from @triple
+		padding-right: @double; // Reduced from @triple
+		position: sticky;
+		top: @user-nav-height; // Stick below the fixed user navigation
+		z-index: 999; // Below user nav (1000) but above content
 	}
 }
 
@@ -57,6 +200,12 @@
 
 // Use the ID so that we override all styles in the base theme
 #navigationPrimary {
+
+	// Ensure list items stack on mobile
+	> li {
+		display: block;
+		margin-bottom: @half; // Add some space between stacked items
+	}
 
 	a {
 		font-family: @font-heading;
@@ -86,6 +235,33 @@
 
 	@media(min-width: @screen-desktop) {
 
+		// Restore default display for desktop if needed (usually inline-block or flex from base theme)
+		// However, specific display is often set by the base theme's desktop styles.
+		// For now, just ensure items are not display:block from our mobile rule.
+		// If they are inline-block or li by default, this is fine.
+		// If the base theme sets display: flex on ul, li will behave as flex items.
+		> li {
+			display: inline-block; // Or whatever the base theme uses for desktop layout
+			margin-bottom: 0; // Reset mobile margin
+			margin-left: 5px; // Create space for separator
+			padding-left: 10px; // Create space for separator
+			position: relative;
+
+			&:not(:first-child)::before {
+				content: "|";
+				position: absolute;
+				left: -2px; // Adjust position of separator
+				top: 50%;
+				transform: translateY(-50%); // Vertically center separator
+				color: darken(@light-slate-gray, 30%); // Color for separator
+			}
+			// Remove separator space for the first child if margin/padding applied to all
+			&:first-child {
+				margin-left: 0;
+				padding-left: 0;
+			}
+		}
+
 		a {
 			color: @text-light;
 
@@ -100,10 +276,13 @@
 
 			a {
 				color: @text-bg-base;
+				padding: @half @double; // Add some padding to submenu links
 
 				&:hover,
 				&:focus {
 					border-color: transparent;
+					background-color: lighten(@bg-base, 10%); // Added hover effect
+					color: @text-bg-base; // Ensure text color remains contrasty
 				}
 			}
 		}
@@ -129,7 +308,7 @@
 			&:hover,
 			&:focus {
 				color: @primary;
-				border-color: @bg-base;
+				border-color: @primary; // Changed to @primary
 			}
 		}
 	}
@@ -147,26 +326,38 @@
 @media(min-width: @screen-desktop) {
 
 	.pkp_navigation_user_wrapper {
-		top: 13px;
+		position: fixed; // Made sticky
+		top: 0;
 		right: 0;
-		left: auto;
-		width: 25%;
+		left: auto; // Keep alignment to the right
+		width: auto; // Adjust width to content
 		transform: none;
-		padding-right: @triple;
+		padding: @half; // Added padding for the bar
+		padding-right: @double; // Keep right padding for content within
+		background: @bg-base; // Added background
+		z-index: 1000; // Ensure it's on top
 
 		a {
-			color: @text-light;
+			color: @text-bg-base; // Ensure text is visible on @bg-base
 		}
 
 		ul a:hover,
 		ul a:focus {
-			border-color: @bg-base;
+			border-color: @accent; // Use accent for hover
 		}
 
 		.pkp_navigation_user {
 			margin-right: 0;
 			padding-right: 0;
 			width: auto;
+			display: flex; // Align items in a row
+
+			> li {
+				margin-left: @base; // Add some spacing between items
+				&:first-child {
+					margin-left: 0;
+				}
+			}
 		}
 	}
 

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -12,26 +12,56 @@
 // A grey background on large screens
 html,
 body {
-	background: @bg-shade;
+	background: @light-slate-gray; // Updated to use the new complementary color directly
+	line-height: 1.6;
+}
+
+p {
+	margin-bottom: 1em;
 }
 
 // A white background for the boxed content area
 .pkp_structure_page {
 	margin: 0 auto;
 	max-width: @screen-lg-desktop-container;
-	background: @bg;
+	background: @bg; // Should still be #fff, contrast is good with light-slate-gray
 	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 
 	@media(min-width: @screen-lg-desktop) {
 		margin-top: @triple;
 		margin-bottom: @triple;
+		padding-top: 5em; // Adjusted for both fixed user nav and sticky primary nav
+	}
+}
+
+@media (max-width: @screen-md-max) { // Assuming @screen-md-max is < @screen-desktop (e.g., <= 991px)
+	.pkp_structure_page {
+		// Adjust page padding for mobile if fixed headers are handled differently
+		// For now, assume fixed headers might not be used or are simpler on mobile
+		padding-top: @base; // Reduce top padding if sticky headers are desktop-only
+	}
+
+	.pkp_structure_main,
+	.pkp_structure_sidebar {
+		float: none;
+		width: 100% !important; // Important to override potential inline styles or more specific rules
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	.pkp_structure_sidebar {
+		padding: @base; // Add some padding for stacked sidebar
+
+		&:before {
+			display: none; // Hide the desktop sidebar border/background pseudo-element
+		}
 	}
 }
 
 .pkp_structure_footer_wrapper {
-	background: @bg-light-shade;
+	background: @bg-light-shade; // Updated via variables.less
 	border-top: @bg-border;
-	border-bottom: @double solid @bg-base;
+	border-bottom: @double solid @primary; // Changed to new @primary for branding
 }
 
 // Removes the left and right borders around the main content panel
@@ -40,8 +70,12 @@ body {
 	display: none;
 }
 
+.pkp_structure_main {
+	padding: 1.5em; // Added padding
+}
+
 .pkp_structure_content {
-	padding-top: 0;
+	padding: 1.5em; // Changed from padding-top: 0; to general padding
 }
 
 .pkp_structure_sidebar {
@@ -55,7 +89,7 @@ body {
 			right: 0;
 			bottom: 0;
 			width: 300px;
-			border-left: @bg-border;
+			border-left: @bg-border-color; // Updated to use the new variable
 		}
 
 		// Child elements need position to appear above the background element
@@ -63,6 +97,27 @@ body {
 			position: relative;
 		}
 	}
+}
+
+// Font size adjustments for very small screens
+@media (max-width: @screen-xs-max) { // Assuming @screen-xs-max is defined (e.g., <= 480px)
+	html, body {
+		font-size: 95%; // Slightly reduce base font size
+	}
+
+	.page_title, // Article Title on article detail page
+	.h1 { // Global h1 class
+		font-size: 2em; // Reduce from 2.5em
+	}
+
+	h2, .h2 {
+		font-size: 1.75em; // Reduce from 2em
+	}
+
+	h3, .h3 {
+		font-size: 1.5em; // Reduce from 1.75em
+	}
+	// Other elements like .pkp_site_name .is_text could also be adjusted if needed
 }
 
 // Center the content panel when no sidebar is present

--- a/styles/objects/article_details.less
+++ b/styles/objects/article_details.less
@@ -10,54 +10,182 @@
  */
 .obj_article_details {
 
+	// Main Article Title
+	.page_title {
+		// Should inherit h1 styles from components.less (font-family, size, weight)
+		margin-bottom: @base;
+	}
+
 	.subtitle {
 		font-family: @font;
+		font-size: 1.2em; // Slightly larger subtitle
+		font-style: italic;
+		margin-bottom: @double;
+		color: @text-light-accessible; // Changed from @text-light
 	}
 
-	.authors,
-	.doi {
+	// Authors block at the top
+	// Assuming this .authors class is used for the primary author list at the top.
+	// If there's a different class or structure, this would need adjustment.
+	.authors {
 		font-family: @font-heading;
+		font-size: 1.1em; // Slightly larger than base text
+		margin-bottom: @base;
+		line-height: 1.6; // Ensure good line height for wrapped author lists
+
+		.author_name { // Class for individual author names
+			font-weight: @bold;
+		}
+
+		.affiliation { // Class for affiliations
+			font-size: 0.9em;
+			color: @text-light-accessible; // Changed from @text-light
+			margin-left: 0.5em;
+		}
+		// ORCID styling will be handled separately to avoid complexity here
 	}
 
-	.orcid a,
-	.doi a {
-		color: @text;
-		text-decoration: none;
+	// DOI block at the top
+	.doi {
+		font-family: @font-heading; // Keep font consistent
+		margin-bottom: @double;
 
-		&:hover,
-		&:focus {
-			color: @primary;
-			text-decoration: underline;
+		a {
+			color: @primary; // Ensure DOI link uses primary color
+			text-decoration: none;
+			word-break: break-all; // Prevent long DOIs from breaking layout
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
 		}
 	}
 
-	.orcid a {
-		font-size: 10px;
-		color: @text-light;
+	// The original .orcid a and .doi a rules might be too general or conflict.
+	// .doi a is now handled above. .orcid a will be addressed next.
+	// The original .authors li rule is also deferred for clarity.
+
+	// ORCID icon styling within the main .authors list
+	.authors .orcid-icon { // Assuming <img class="orcid-icon"> or <span class="orcid-icon">
+		display: inline-block;
+		width: 1em; // Relative to parent (.authors) font-size
+		height: 1em; // Relative to parent (.authors) font-size
+		vertical-align: middle;
+		margin-left: 0.3em;
+		position: relative; // For fine-tuning
+		top: -0.1em; // Adjust as needed for specific icon
 	}
 
-	.authors li {
+	// Specific styling for the .authors li that is likely for author biographies
+	// to avoid conflict with any potential <li> usage in the top authors list.
+	.author_bios .authors_list > li { // Assuming a structure like .author_bios > ul.authors_list > li
 		margin-bottom: @double;
+		padding-left: 0; // Reset any list padding if needed
+		list-style-type: none; // Remove bullets if it's a list of bios
 	}
+	// Comment out or remove the old generic .orcid a and .authors li if they are now handled
+	// .orcid a { ... } // Handled by .authors .orcid-icon or direct link styling if applicable
+	// .authors li { ... } // Handled by .author_bios .authors_list > li
+
+	// Abstract styling
+	.abstract {
+		margin-bottom: @double;
+		// Assuming .label or a heading tag is used for "Abstract" title
+		// Text styling (font-size, line-height) inherited from body or .obj_article_details
+	}
+
+	// Keywords styling
+	.keywords {
+		margin-bottom: @double;
+
+		// Assuming .label or a heading tag is used for "Keywords" title
+		.value p, .value { // Assuming keywords are in a <p> or directly in .value
+			display: flex; // Use flexbox for keyword badges
+			flex-wrap: wrap; // Allow wrapping
+			gap: 0.5em; // Space between keyword badges
+		}
+
+		.keyword { // Class for individual keyword items
+			background-color: @bg-shade;
+			color: @text;
+			padding: 0.25em 0.75em; // Adjusted padding for better appearance
+			border-radius: @radius;
+			font-size: 0.9em; // Slightly smaller font for keywords
+			// display: inline-block; // Not needed with flex parent
+			// margin-right: 0.5em; // Handled by gap
+			// margin-bottom: 0.5em; // Handled by gap and flex-wrap
+		}
+	}
+
 
 	.main_entry {
 
-		.label {
-			display: inline-block;
-			padding: 0 0 @half;
+		.label { // General style for labels like Abstract, Issue, etc.
+			display: block; // Make label take full width
+			font-family: @font-heading;
+			font-size: 1.5em; // Make it like an H3/H4
+			font-weight: @bold;
+			padding-bottom: @half;
+			margin-bottom: @base;
 			border-bottom: 3px solid @accent;
-			color: @text-light;
+			color: @text-strong; // Use a stronger color for labels
 			text-transform: uppercase;
 		}
 
-		.doi .label,
-		.keywords .label {
-			display: inline;
-			padding: 0;
+		// Specific overrides for labels that should NOT look like big headings
+		&.doi .label, // If .doi is a .main_entry itself
+		&.keywords .label { // If .keywords is a .main_entry itself
+			// This might need adjustment based on HTML. If .label is *inside* .doi or .keywords div,
+			// then selectors like .doi > .label would be better.
+			// For now, assuming .doi and .keywords might also be .main_entry blocks.
+			display: inline; // Revert to inline for these specific labels if they are not titles
+			font-size: 1em; // Revert font size
+			font-weight: @normal;
 			border: none;
 			text-transform: none;
+			color: @text-light-accessible; // Changed from @text-light
+			margin-bottom: 0;
 		}
 	}
+
+	// Section headings within the main article content (e.g. Introduction, Methods)
+	// Assuming article content is in a div like .article_body_content
+	.article_body_content {
+		h2, h3, h4 { // Target h2, h3, h4 used as section titles
+			// Should inherit font-family, size, weight from global H_ styles in components.less
+			margin-top: @double;
+			margin-bottom: @base;
+		}
+	}
+
+	// References section styling
+	.references {
+		// Assuming "References" title is handled by .main_entry .label or a h_ tag
+		margin-top: @double; // Space above references section
+		margin-bottom: @double; // Space below references section
+
+		ul, ol {
+			padding-left: @double; // Standard indentation for lists
+			list-style-position: outside;
+		}
+
+		li, p { // Target list items or paragraphs if references are not in a list
+			margin-bottom: @half;
+			line-height: @line-height-base; // Ensure consistent line height (assuming @line-height-base is defined, e.g. 1.6)
+
+			a {
+				color: @primary; // Ensure links within references use primary color
+				text-decoration: none;
+				word-break: break-all; // Break long URLs/DOIs
+
+				&:hover, &:focus {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+
 
 	.row,
 	.main_entry,
@@ -108,7 +236,7 @@
 			}
 
 			.label {
-				color: @text-light;
+				color: @text-light-accessible; // Changed from @text-light
 			}
 		}
 

--- a/styles/objects/article_summary.less
+++ b/styles/objects/article_summary.less
@@ -9,9 +9,100 @@
  * @link templates/frontend/objects/article_summary.tpl
  */
 .obj_article_summary {
+	border: 1px solid @bg-border-color;
+	border-radius: @radius;
+	padding: @base;
+	margin-bottom: @double; // This might be overridden by grid gap if used
+	background-color: @bg;
+	box-shadow: @shadow-sm;
+	display: flex; // Use flexbox for layout within the card
+	flex-direction: column; // Stack items vertically
+	height: 100%; // Make card take full height if in a grid
 
-	.subtitle {
+	.cover_image { // Assuming a div wrapper for the image
+		margin-bottom: @base;
+		text-align: center; // Center image if it's narrower than card
+
+		img {
+			max-width: 100%;
+			height: auto;
+			border-radius: @radius; // Optional: round corners of image
+		}
+	}
+
+	.title {
+		// Should inherit h3/h4 styles from components.less
+		// Ensure it's a block element for proper spacing if it's a link
+		display: block;
+		margin-bottom: @half;
+
+		a {
+			text-decoration: none; // Remove underline from title link
+			color: @text-strong; // Use strong text color for title link
+
+			&:hover, &:focus {
+				color: @primary;
+				text-decoration: underline; // Underline on hover for title link
+			}
+		}
+	}
+
+	.subtitle { // Existing style from original file
 		font-family: @font;
 		font-size: @font-sml;
+		color: @text-light-accessible; // Changed from @text-light
+		margin-bottom: @half; // Added margin for subtitle
+	}
+
+	.authors {
+		font-size: 0.9em;
+		color: @text-light-accessible; // Changed from @text-light
+		margin-bottom: @base;
+		line-height: 1.4; // Slightly tighter line height for authors
+	}
+
+	.abstract { // Or .article_summary_abstract, .description etc.
+		font-size: 0.9em;
+		margin-bottom: @base;
+		line-height: 1.5;
+		flex-grow: 1; // Allow abstract to take available space, pushing "Read More" down
+	}
+
+	.read_more {
+		display: inline-block;
+		margin-top: auto; // Push to bottom if abstract doesn't fill space
+		padding-top: @half; // Ensure space above if abstract is short
+		color: @primary;
+		font-weight: @bold;
+		text-decoration: none;
+
+		&:hover, &:focus {
+			text-decoration: underline;
+			color: darken(@primary, 10%);
+		}
+	}
+
+	.article_type_badge { // Placeholder for article type (e.g., Review, Research)
+		font-size: 0.8em;
+		background-color: @accent;
+		color: #333333; // Changed from @text-bg-base for better contrast on @accent
+		padding: 0.2em 0.5em;
+		border-radius: @radius;
+		display: inline-block;
+		margin-bottom: @base; // Space below badge, before title or other content
+		// Could also be absolutely positioned at a corner of the card
+	}
+
+	// Ensure that if the card is a link itself, it behaves correctly
+	// This is common if the entire card is clickable
+	a.obj_article_summary_link_wrapper {
+		text-decoration: none;
+		color: inherit; // Inherit text color for contents
+
+		&:hover, &:focus {
+			// Optional: add hover effect to the card itself
+			// box-shadow: @shadow-md;
+			// border-color: darken(@bg-border-color, 10%);
+		}
 	}
 }

--- a/styles/objects/galley_link.less
+++ b/styles/objects/galley_link.less
@@ -9,20 +9,41 @@
  * @link templates/frontend/objects/galley_link.tpl
  */
 .obj_galley_link {
-	&:extend(.cmp_manuscript_button all);
+	&:extend(.cmp_manuscript_button all); // Extends base button styles
+	background-color: @primary; // Prominent background using deep gold
+	color: @text-bg-base;      // Text color for contrast
+	padding: @half @base;       // Specific padding for galley links
+	border-radius: @radius;     // Rounded corners
+	margin-bottom: @half;       // Space below if they stack
+	margin-right: @half;        // Space to the side if they are inline-block (depends on parent)
+	text-align: center;         // Ensure text is centered
+	display: inline-block;      // Allow side-by-side placement with margin
+
+	&:hover,
+	&:focus {
+		background-color: darken(@primary, 10%); // Darken on hover/focus
+		color: @text-bg-base; // Ensure text color remains contrasted
+	}
 
 	&.restricted {
-		border-color: @bg-shade;
-		background: @bg-shade;
-		color: @text-light;
+		// Keep restricted style distinct, but ensure it's still button-like
+		background-color: @bg-shade; // Original background for restricted
+		border-color: @bg-border-color; // Use consistent border color
+		color: @text-light; // Original text color
+		padding: @half @base; // Consistent padding
+		border-radius: @radius; // Consistent radius
 
-		&:before {
-			color: @text-light;
+		&:before { // Assuming this is for an icon (e.g., lock)
+			color: @text-light; // Keep icon color
 		}
 
 		&:hover,
 		&:focus {
-			background: @text-light;
+			background-color: darken(@bg-shade, 5%); // Slightly darken restricted button on hover
+			color: @text-light;
 		}
 	}
+
+	// If there are specific PDF/HTML types, they can be further customized
+	// e.g., .pdf_galley_link, .html_galley_link
 }

--- a/styles/objects/issue_toc.less
+++ b/styles/objects/issue_toc.less
@@ -74,4 +74,25 @@
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	// Apply grid layout to the container of article summaries within a section
+	// Note: If .section directly contains both h2 and article summaries,
+	// the h2 will also be a grid item. Ideally, article summaries are wrapped
+	// in a dedicated child container (e.g., <div class="articles_in_section">).
+	.section {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		gap: @double; // Use the same as article_summary margin-bottom for consistency
+
+		// Ensure h2 spans full width if it's part of this grid
+		> h2 {
+			grid-column: 1 / -1; // Make h2 span all columns
+			margin-bottom: @base; // Ensure space below h2 before articles
+		}
+
+		// Reset margin for article summaries if grid gap handles spacing
+		> .obj_article_summary {
+			margin-bottom: 0; // Grid gap will handle spacing
+		}
+	}
 }

--- a/styles/pages/indexJournal.less
+++ b/styles/pages/indexJournal.less
@@ -72,6 +72,15 @@
 
 		.sections {
 			margin-top: @double;
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+			gap: @double;
+
+			// Reset margin for article summaries if grid gap handles spacing
+			// Assuming .obj_article_summary are direct children or within a wrapper that's a direct child
+			.obj_article_summary {
+				margin-bottom: 0; // Grid gap will handle spacing
+			}
 		}
 
 		.read_more {

--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -10,17 +10,42 @@
  */
 
 .pkp_block {
+	border: 1px solid @bg-border-color;
+	padding: @base;
+	margin-bottom: @double;
+	border-radius: @radius;
 
 	.title {
-		display: inline-block;
-		padding-bottom: 0.5em;
-		border-bottom: 3px solid @accent;
-		font-weight: @bold;
-		text-transform: uppercase;
+		display: inline-block; // Keeps it from taking full width if text is short
+		padding-bottom: 0.5em; // Original padding
+		border-bottom: 3px solid @accent; // Original border
+		font-weight: @bold; // Original font-weight
+		text-transform: uppercase; // Original text-transform
+		margin-bottom: @base; // Add some space below the title before block content
+		// Remove margin-top from title if block has padding, or adjust title positioning
+		margin-top: 0; // Assuming padding on .pkp_block handles top spacing
 	}
 
+	// Adjustments for content within the block if using padding on .pkp_block
+	// For example, if lists or other elements inside have their own margins
+	> *:last-child {
+		margin-bottom: 0; // Remove bottom margin from last child inside block
+	}
 }
 
 .block_make_submission a {
-	&:extend(.cmp_manuscript_button all);
+	&:extend(.cmp_manuscript_button all); // Keep existing base, but override below
+	background-color: @primary; // Use the new primary color (deep gold)
+	color: @text-bg-base; // Ensure good contrast (should be fine as @primary is dark gold)
+	padding: @base @double;
+	text-align: center;
+	display: block; // Make it full-width within its container
+	border-radius: @radius; // Add rounded corners
+	// text-transform: uppercase; // Already from .cmp_manuscript_button
+	// font-weight: @bold; // Already from .cmp_manuscript_button
+
+	&:hover, &:focus {
+		background-color: darken(@primary, 10%);
+		color: @text-bg-base; // Ensure contrast on hover too
+	}
 }

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -15,21 +15,32 @@
 
 // Background
 @bg:                     #fff;
-@bg-shade:               #ddd;
-@bg-light-shade:         rgba(0,0,0,0.05);
-@bg-base:                #4b7d92; // Accent color used in the header
-@text-bg-base:           #fff;
+@bg-shade:               #f0f2f5; // New light slate gray
+@bg-light-shade:         rgba(0,0,0,0.03); // Lighter version of slate gray
+@bg-base:                #426c7f; // Darkened for better contrast with white text (was #4b7d92)
+@text-bg-base:           #fff; // Ensure good contrast with @bg-base
+
+// Text specific colors
+@text-light-accessible:  #6c6c6c; // For better contrast than default @text-light on white bg
+
+// Complementary colors
+@deep-gold:              #b58500;
+@light-slate-gray:       #f0f2f5;
 
 // Primary "anchor" color for links
-@primary:                #4b7d92;
+@primary:                @deep-gold; // New deep gold
 @primary-lift:           lighten(@primary, 10%);
 
 // Accent color
-@accent:                 #f7bc4a;
+@accent:                 #cda300; // Brighter version of deep gold
 
 // Border colors
-@bg-border-color:        @bg-shade;
+@bg-border-color:        #e0e2e5; // Slightly darker shade of new @bg-shade
 
 // Font
-@font:  "Noto Serif", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-@font-heading:  "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+@font:  "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+@font-heading:  "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+
+// Shadows
+@shadow-sm: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+@shadow-md: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);


### PR DESCRIPTION
This commit includes two main parts:

1.  Updates `DefaultManuscriptChildThemePlugin.php` to use `addStyle('defaultManuscriptChildStylesheet', ...)` instead of `modifyStyle('stylesheet', ...)`. This is an attempt to resolve an issue where the theme's stylesheet URL was being malformed (containing '$$$call$$$'), leading to unstyled pages. Registering with a unique ID aims to sidestep potential conflicts or processing errors related to the generic 'stylesheet' ID.

2.  This commit also incorporates all previously developed UI/UX enhancements for the OJS theme, as detailed in the prior commit message on this branch. This includes improvements to branding, color palette, typography, header/navigation, layout, article display, metadata presentation, mobile responsiveness, and accessibility.

After this commit, the theme should be testable with the new stylesheet registration method and all visual and functional styling changes.